### PR TITLE
README and Makefile tweaks to get around some minor obstacles

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you read the [blog post](https://towardsdatascience.com/a-serverless-query-en
 
 Make sure you have:
 
-- A working AWS account;
+- A working AWS account and an access key with [sufficient priviledges to deploy a lambda instance](https://www.serverless.com/framework/docs/providers/aws/guide/credentials) -- this could be the `AdministratorAccess` policy in AWS IAM, or something more fine grained;
 - [Docker](https://docs.docker.com/get-docker/) installed and running on your machine;
 - Python 3.9+ and Node.js properly installed on your machine;
 - A `profiles.yaml` file on your local machine to run the dbt project.
@@ -35,7 +35,7 @@ These variables will be used by the setup script and the runner to communicate w
 ### Run the project
 From the `src` folder:
 
->**1. Create the DuckDB Lambda:** run `make nodejs-init` and then `make serverless-deploy` (after deployment, you can test the lambda is working from the [console](https://www.loom.com/share/97785a387af84924b830b9e0f35d8a1e)).
+>**1. Create the DuckDB Lambda:** run `make nodejs-init` and then `make serverless-deploy`.  Note that `src/serverless.yml` is configured to use `arm64`. This does a local Docker build, so if you're on an `x86_64` machine, it will fail.  Replace `arm64` with `x86_64` as needed.  After deployment, you can test the lambda is working from the [console](https://www.loom.com/share/97785a387af84924b830b9e0f35d8a1e).
 
 >**2. Build the Python env:** run `make python-init`.
 
@@ -56,7 +56,7 @@ duckdb-taxi:
         - parquet
   target: dev
 ```
->**6. Run the dbt project:** run make `dbt-run`.
+>**6. Run the dbt project:** run `make dbt-run`.
 
 >**7. Run the Analytics app:** run `make dashboard`.
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,8 @@
 include .env
 
+# need bash because we use the "source" command (otherwise it fails when make defaults to /bin/sh)
+SHELL=bash
+
 nodejs-init:
 	npm install
 .PHONY: nodejs-init
@@ -17,15 +20,15 @@ run_me_first:
 .PHONY: run_me_first
 
 test:
-	source ./.venv/bin/activate && python quack.py
+	source ./.venv/bin/activate && python3 quack.py
 .PHONY: test
 
 test-distinct:
-	source ./.venv/bin/activate && python quack.py -q "SELECT pickup_location_id AS location_id, COUNT(*) AS counts FROM read_parquet(['s3://${S3_BUCKET_NAME}/dataset/taxi_2019_04.parquet']) WHERE pickup_at >= '2019-04-01' AND pickup_at < '2019-04-03' GROUP BY 1 ORDER BY 2 DESC"
+	source ./.venv/bin/activate && python3 quack.py -q "SELECT pickup_location_id AS location_id, COUNT(*) AS counts FROM read_parquet(['s3://${S3_BUCKET_NAME}/dataset/taxi_2019_04.parquet']) WHERE pickup_at >= '2019-04-01' AND pickup_at < '2019-04-03' GROUP BY 1 ORDER BY 2 DESC"
 .PHONY: test-distinct
 
 benchmark:
-	source ./.venv/bin/activate && python benchmark.py
+	source ./.venv/bin/activate && python3 benchmark.py
 .PHONY: benchmark
 
 dbt-run:


### PR DESCRIPTION
This solves 3 issues I ran into when following along:
1. I was on an x86_64 VM and the Docker build fails with no explanation about the arch
2. I had trouble determining the minimum ACLs needed to "npx serverless deploy", so added a note about what is needed
3. "source", used in the Makefile, is a bash command (and perhaps command in other shells?).  My make was defaulting to /bin/sh, which lacks a "source" command, so I added an env variable to only use bash